### PR TITLE
2026-1-28 fix PrestigeLevel of dogtags

### DIFF
--- a/Patches/AddDogTagToBot.cs
+++ b/Patches/AddDogTagToBot.cs
@@ -31,6 +31,10 @@ public class AddDogTagToBot_Patch : AbstractPatch
     [PatchPrefix]
     public static bool Prefix(BotBase bot)
     {
+        if (bot.Info.ExtensionData is not null &&
+            bot.Info.ExtensionData.TryGetValue("PrestigeLevel", out var storedPrestigeObj) &&
+            storedPrestigeObj is int storedPrestige)
+                bot.Info.PrestigeLevel = storedPrestige;
         Item inventoryItem = new()
         {
             Id = new MongoId(),

--- a/Patches/GenerateBotLevel.cs
+++ b/Patches/GenerateBotLevel.cs
@@ -63,6 +63,7 @@ public class GenerateBotLevel : AbstractPatch
         bot.Info.AddToExtensionData("Tier", tierHelper.GetTierByLevel(level));
         botGenerationDetails.AddToExtensionData("Tier", tierHelper.GetTierByLevel(level));
         bot.Info.PrestigeLevel = SetBotPrestigeInfo(level, botGenerationDetails);
+        bot.Info.AddToExtensionData("PrestigeLevel", bot.Info.PrestigeLevel);
         
         var baseExp = expTable.Take(level).Sum(entry => entry.Experience);
         var fractionalExp = level < maxLevelIndex ? randomUtil.GetInt(0, expTable[level].Experience - 1) : 0;


### PR DESCRIPTION
The vanilla SPT bot generator will overwrite PrestigeLevel before dogtag patches. So I add a backup of PrestigeLv calculated by APBS.
Should fix no prestiged dogtags in previous versions.