### PR TITLE
Update GenerateBotLevel.cs to remove duplicated `PrestigeLevel` key/property from bot object.

### DIFF
--- a/Patches/GenerateBotLevel.cs
+++ b/Patches/GenerateBotLevel.cs
@@ -63,7 +63,6 @@ public class GenerateBotLevel : AbstractPatch
         
         bot.Info.PrestigeLevel = SetBotPrestigeInfo(level, botGenerationDetails);
         bot.Info.AddToExtensionData("Tier", tierHelper.GetTierByLevel(level));
-        bot.Info.AddToExtensionData("PrestigeLevel", bot.Info.PrestigeLevel);
         botGenerationDetails.AddToExtensionData("Tier", tierHelper.GetTierByLevel(level));
         
         var baseExp = expTable.Take(level).Sum(entry => entry.Experience);


### PR DESCRIPTION
Unsure if this would cause any other/bring back old issue for APBS.

When other mods interact with bot generation by parsing from Async `ValueTask<string>` passed down from APBS, the JSON object created will thus contain duplicate `PrestigeLevel` key, causing the other mod to fail.

If this was intentional and purposeful for any reason, please let me know and reject this pull request.  I will look for other way to interact with bot generation instead of by `ValueTask`.

Or REGEX the duplicated key out of the to-be-parsed JSON string value.